### PR TITLE
Modify error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ const unsubscribe = await subscribeToQuery({
     // }
     console.error(error);
   },
+  onError: (error) => {
+    // error will be
+    // {
+    //   message: "ERROR MESSAGE"
+    // }
+    console.log(error.message);
+  },
+  onEvent: (event) => {
+    // event will be
+    // {
+    //   status: "connected|connected|closed",
+    //   channelUrl: "...",
+    //   message: "MESSAGE",
+    // }
+  },
 });
 ```
 
@@ -74,6 +89,8 @@ const unsubscribe = await subscribeToQuery({
 | onUpdate           | function                                                                                  | :white_check_mark: | Callback function to receive query update events                   |                                      |
 | onChannelError     | function                                                                                  | :x:                | Callback function to receive channelError events                   |                                      |
 | onStatusChange     | function                                                                                  | :x:                | Callback function to receive status change events                  |                                      |
+| onError            | function                                                                                  | :x:                | Callback function to receive error events                          |                                      |
+| onEvent            | function                                                                                  | :x:                | Callback function to receive other events                          |                                      |
 | variables          | Object                                                                                    | :x:                | GraphQL variables for the query                                    |                                      |
 | preview            | boolean                                                                                   | :x:                | If true, the Content Delivery API with draft content will be used  | false                                |
 | environment        | string                                                                                    | :x:                | The name of the DatoCMS environment where to perform the query     | defaults to primary environment      |
@@ -109,6 +126,28 @@ The `errorData` argument has the following properties:
 | code     | string | The code of the error (ie. `INVALID_QUERY`)             |
 | message  | string | An human friendly message explaining the error          |
 | response | Object | The raw response returned by the endpoint, if available |
+
+### `onError(error: ErrorData)`
+
+This function is called when connection errors occur.
+
+The `error` argument has the following properties:
+
+| prop     | type   | description                                             |
+| -------- | ------ | ------------------------------------------------------- |
+| message  | string | An human friendly message explaining the error          |
+
+### `onEvent(event: EventData)`
+
+This function is called then other events occur.
+
+The `event` argument has the following properties:
+
+| prop       | type   | description                                             |
+| ---------- | ------ | ------------------------------------------------------- |
+| status     | string | The current connection status (see above)               |
+| channelUrl | string | The current channel URL                                 |
+| message    | string | An human friendly message explaining the event          |
 
 ## Return value
 

--- a/src/subscribeToQuery/__tests__/index.test.ts
+++ b/src/subscribeToQuery/__tests__/index.test.ts
@@ -1,11 +1,16 @@
 import { ChannelErrorData, Options, subscribeToQuery } from "../index";
 import pDefer from "p-defer";
 
-const makeFakeFetch = () => {
+type FakeFetchOptions = {
+  /** The number of 500 errors to generate, default: 1 **/
+  serverErrors?: number;
+};
+
+const makeFakeFetch = ({serverErrors = 1}: FakeFetchOptions = {}) => {
   let times = 0;
 
   const fetcher = async () => {
-    if (times === 0) {
+    if (times < serverErrors) {
       times += 1;
 
       return {

--- a/src/subscribeToQuery/__tests__/index.test.ts
+++ b/src/subscribeToQuery/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { ChannelErrorData, ErrorData, Options, subscribeToQuery } from "../index";
+import { ChannelErrorData, ErrorData, EventData, Options, subscribeToQuery } from "../index";
 import pDefer from "p-defer";
 
 type FakeFetchOptions = {
@@ -171,6 +171,28 @@ describe("subscribeToQuery", () => {
 
     const data = await onUpdateEventDefer.promise;
     expect(data).toEqual(true);
+  });
+
+  it("notifies events", async () => {
+    const fetcher = makeFakeFetch();
+    const onEventDefer = pDefer<EventData>();
+
+    subscribeToQuery({
+      query: `{ allBlogPosts(first: 1) { title } }`,
+      token: `XXX`,
+      preview: true,
+      environment: "foobar",
+      reconnectionPeriod: 10,
+      fetcher,
+      eventSourceClass: MockEventSource,
+      onUpdate: (data) => {},
+      onEvent: (event) => {
+        onEventDefer.resolve(event);
+      },
+    });
+
+    const event = await onEventDefer.promise;
+    expect(event.channelUrl).toEqual("bar");
   });
 
   it("notifies errors", async () => {

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -48,6 +48,15 @@ export type ErrorData = {
   message: string;
 };
 
+export type EventData = {
+  /** The current status of the connection **/
+  status: ConnectionStatus;
+  /** The current channelUrl **/
+  channelUrl: string;
+  /** An event description **/
+  message: string;
+};
+
 export type Options<QueryResult, QueryVariables> = {
   /** The GraphQL query to subscribe */
   query: string;
@@ -84,6 +93,8 @@ export type Options<QueryResult, QueryVariables> = {
   onChannelError?: (errorData: ChannelErrorData) => void;
   /** Callback function to call on other errors */
   onError?: (errorData: ErrorData) => void;
+  /** Callback function to call on events during the connection lifecycle */
+  onEvent?: (eventData: EventData) => void;
 };
 
 export type UnsubscribeFn = () => void;
@@ -125,6 +136,7 @@ export async function subscribeToQuery<
     onUpdate,
     onChannelError,
     onError,
+    onEvent,
     reconnectionPeriod: customReconnectionPeriod,
     baseUrl: customBaseUrl,
   } = options;
@@ -183,6 +195,9 @@ export async function subscribeToQuery<
     const registration = await req.json();
 
     channelUrl = registration.url;
+    if (onEvent) {
+      onEvent({status: 'connecting', channelUrl, message: 'Received channel URL'});
+    }
   } catch (e) {
     if (e instanceof Response400Error || e instanceof InvalidResponseError) {
       throw e;

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -238,15 +238,21 @@ export async function subscribeToQuery<
       const errorData = JSON.parse((event as any).data) as ChannelErrorData;
 
       if (errorData.fatal) {
-        if (onStatusChange) {
-          onStatusChange('closed');
-        }
         stopReconnecting = true;
-        unsubscribe();
       }
 
       if (onChannelError) {
         onChannelError(errorData);
+      }
+
+      eventSource.close();
+
+      if (onStatusChange) {
+        onStatusChange('closed');
+      }
+
+      if (!stopReconnecting) {
+        waitAndReconnect();
       }
     });
 

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -203,6 +203,10 @@ export async function subscribeToQuery<
       onError(e)
     }
 
+    if (onStatusChange) {
+      onStatusChange('closed');
+    }
+
     return waitAndReconnect();
   }
 
@@ -248,6 +252,10 @@ export async function subscribeToQuery<
 
     eventSource.addEventListener('onerror', (event) => {
       eventSource.close();
+
+      if (onStatusChange) {
+        onStatusChange('closed');
+      }
 
       if (onError) {
         onError(event)

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -199,10 +199,6 @@ export async function subscribeToQuery<
       onEvent({status: 'connecting', channelUrl, message: 'Received channel URL'});
     }
   } catch (e) {
-    if (e instanceof Response400Error || e instanceof InvalidResponseError) {
-      throw e;
-    }
-
     if (onError) {
       onError(e)
     }


### PR DESCRIPTION
This commit adds two callbacks, `onError` and `onEvent` to improve observability.

Attempts are made to recover from more error conditions, to avoid zombie connections that never reach 'connected' state.