### PR TITLE
Modify error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ const unsubscribe = await subscribeToQuery({
     // }
     console.error(error);
   },
+  onError: (error) => {
+    // error will be
+    // {
+    //   message: "ERROR MESSAGE"
+    // }
+    console.log(error.message);
+  },
+  onEvent: (event) => {
+    // event will be
+    // {
+    //   status: "connected|connected|closed",
+    //   channelUrl: "...",
+    //   message: "MESSAGE",
+    // }
+  },
 });
 ```
 
@@ -74,6 +89,8 @@ const unsubscribe = await subscribeToQuery({
 | onUpdate           | function                                                                                  | :white_check_mark: | Callback function to receive query update events                   |                                      |
 | onChannelError     | function                                                                                  | :x:                | Callback function to receive channelError events                   |                                      |
 | onStatusChange     | function                                                                                  | :x:                | Callback function to receive status change events                  |                                      |
+| onError            | function                                                                                  | :x:                | Callback function to receive error events                          |                                      |
+| onEvent            | function                                                                                  | :x:                | Callback function to receive other events                          |                                      |
 | variables          | Object                                                                                    | :x:                | GraphQL variables for the query                                    |                                      |
 | preview            | boolean                                                                                   | :x:                | If true, the Content Delivery API with draft content will be used  | false                                |
 | environment        | string                                                                                    | :x:                | The name of the DatoCMS environment where to perform the query     | defaults to primary environment      |
@@ -109,6 +126,28 @@ The `errorData` argument has the following properties:
 | code     | string | The code of the error (ie. `INVALID_QUERY`)             |
 | message  | string | An human friendly message explaining the error          |
 | response | Object | The raw response returned by the endpoint, if available |
+
+### `onError(error: ErrorData)`
+
+This function is called when connection errors occur.
+
+The `error` argument has the following properties:
+
+| prop     | type   | description                                             |
+| -------- | ------ | ------------------------------------------------------- |
+| message  | string | An human friendly message explaining the error          |
+
+### `onEvent(event: EventData)`
+
+This function is called then other events occur.
+
+The `event` argument has the following properties:
+
+| prop       | type   | description                                             |
+| ---------- | ------ | ------------------------------------------------------- |
+| status     | string | The current connection status (see above)               |
+| channelUrl | string | The current channel URL                                 |
+| message    | string | An human friendly message explaining the event          |
 
 ## Return value
 

--- a/src/subscribeToQuery/__tests__/index.test.ts
+++ b/src/subscribeToQuery/__tests__/index.test.ts
@@ -197,7 +197,7 @@ describe("subscribeToQuery", () => {
 
   it("notifies errors", async () => {
     const fetcher = makeFakeFetch({serverErrors: 0});
-    const onErrorDefer = pDefer<ErrorEvent>();
+    const onErrorDefer = pDefer<MessageEvent>();
 
     subscribeToQuery({
       query: `{ allBlogPosts(first: 1) { title } }`,
@@ -220,13 +220,16 @@ describe("subscribeToQuery", () => {
     }, 100);
 
     setTimeout(() => {
-      const error = {
+      const data = JSON.stringify({
         message: "Not Found"
-      };
+      });
+      const error = new MessageEvent('FetchError', {data});
       streams[0].listeners["onerror"].forEach((cb) => cb(error));
     }, 200);
 
     const error = await onErrorDefer.promise;
-    expect(error.message).toEqual("Not Found");
+    console.log('error:', error);
+    const data = JSON.parse(error.data);
+    expect(data.message).toEqual("Not Found");
   });
 });

--- a/src/subscribeToQuery/__tests__/index.test.ts
+++ b/src/subscribeToQuery/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { ChannelErrorData, ErrorData, EventData, Options, subscribeToQuery } from "../index";
+import { ChannelErrorData, EventData, Options, subscribeToQuery } from "../index";
 import pDefer from "p-defer";
 
 type FakeFetchOptions = {
@@ -197,7 +197,7 @@ describe("subscribeToQuery", () => {
 
   it("notifies errors", async () => {
     const fetcher = makeFakeFetch({serverErrors: 0});
-    const onErrorDefer = pDefer<ErrorData>();
+    const onErrorDefer = pDefer<ErrorEvent>();
 
     subscribeToQuery({
       query: `{ allBlogPosts(first: 1) { title } }`,
@@ -227,6 +227,6 @@ describe("subscribeToQuery", () => {
     }, 200);
 
     const error = await onErrorDefer.promise;
-    expect(error.error.message).toEqual("Not Found");
+    expect(error.message).toEqual("Not Found");
   });
 });

--- a/src/subscribeToQuery/__tests__/index.test.ts
+++ b/src/subscribeToQuery/__tests__/index.test.ts
@@ -1,11 +1,16 @@
 import { ChannelErrorData, Options, subscribeToQuery } from "../index";
 import pDefer from "p-defer";
 
-const makeFakeFetch = () => {
+type FakeFetchOptions = {
+  /** The number of 500 errors to generate, default: 1 **/
+  serverErrors?: number;
+};
+
+const makeFakeFetch = ({serverErrors = 1}: FakeFetchOptions = {}) => {
   let times = 0;
 
   const fetcher = async () => {
-    if (times === 0) {
+    if (times < serverErrors) {
       times += 1;
 
       return {

--- a/src/subscribeToQuery/__tests__/index.test.ts
+++ b/src/subscribeToQuery/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { ChannelErrorData, ErrorData, Options, subscribeToQuery } from "../index";
+import { ChannelErrorData, ErrorData, EventData, Options, subscribeToQuery } from "../index";
 import pDefer from "p-defer";
 
 type FakeFetchOptions = {
@@ -171,6 +171,28 @@ describe("subscribeToQuery", () => {
 
     const data = await onUpdateEventDefer.promise;
     expect(data).toEqual(true);
+  });
+
+  it("notifies events", async () => {
+    const fetcher = makeFakeFetch();
+    const onEventDefer = pDefer<EventData>();
+
+    subscribeToQuery({
+      query: `{ allBlogPosts(first: 1) { title } }`,
+      token: `XXX`,
+      preview: true,
+      environment: "foobar",
+      reconnectionPeriod: 10,
+      fetcher,
+      eventSourceClass: MockEventSource,
+      onUpdate: (data) => {},
+      onEvent: (event) => {
+        onEventDefer.resolve(event);
+      },
+    });
+
+    const event = await onEventDefer.promise;
+    expect(event.channelUrl).toEqual("bar");
   });
 
   it("notifies errors", async () => {

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -48,6 +48,15 @@ export type ErrorData = {
   message: string;
 };
 
+export type EventData = {
+  /** The current status of the connection **/
+  status: ConnectionStatus;
+  /** The current channelUrl **/
+  channelUrl: string;
+  /** An event description **/
+  message: string;
+};
+
 export type Options<QueryResult, QueryVariables> = {
   /** The GraphQL query to subscribe */
   query: string;
@@ -84,6 +93,8 @@ export type Options<QueryResult, QueryVariables> = {
   onChannelError?: (errorData: ChannelErrorData) => void;
   /** Callback function to call on other errors */
   onError?: (errorData: ErrorData) => void;
+  /** Callback function to call on events during the connection lifecycle */
+  onEvent?: (eventData: EventData) => void;
 };
 
 export type UnsubscribeFn = () => void;
@@ -125,6 +136,7 @@ export async function subscribeToQuery<
     onUpdate,
     onChannelError,
     onError,
+    onEvent,
     reconnectionPeriod: customReconnectionPeriod,
     baseUrl: customBaseUrl,
   } = options;
@@ -183,6 +195,9 @@ export async function subscribeToQuery<
     const registration = await req.json();
 
     channelUrl = registration.url;
+    if (onEvent) {
+      onEvent({status: 'connecting', channelUrl, message: 'Received channel URL'});
+    }
   } catch (e) {
     if (e instanceof Response400Error || e instanceof InvalidResponseError) {
       throw e;

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -43,11 +43,6 @@ function endpointFactory({
 
 export type ConnectionStatus = 'connecting' | 'connected' | 'closed';
 
-export type ErrorData = {
-  /** The error message returned by the EventSource **/
-  message: string;
-};
-
 export type EventData = {
   /** The current status of the connection **/
   status: ConnectionStatus;
@@ -92,7 +87,7 @@ export type Options<QueryResult, QueryVariables> = {
   /** Callback function to call on channel errors */
   onChannelError?: (errorData: ChannelErrorData) => void;
   /** Callback function to call on other errors */
-  onError?: (errorData: ErrorData) => void;
+  onError?: (errorData: ErrorEvent) => void;
   /** Callback function to call on events during the connection lifecycle */
   onEvent?: (eventData: EventData) => void;
 };
@@ -204,7 +199,8 @@ export async function subscribeToQuery<
     }
 
     if (onError) {
-      onError(e)
+      const event = new ErrorEvent('FetchError', {message: e.message});
+      onError(event)
     }
 
     if (onStatusChange) {
@@ -268,7 +264,7 @@ export async function subscribeToQuery<
       }
 
       if (onError) {
-        onError(event)
+        onError(event as ErrorEvent);
       }
 
       if (!stopReconnecting) {

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -194,7 +194,7 @@ export async function subscribeToQuery<
       onEvent({status: 'connecting', channelUrl, message: 'Received channel URL'});
     }
   } catch (e) {
-    if (e instanceof Response400Error || e instanceof InvalidResponseError) {
+    if (e instanceof Response400Error) {
       throw e;
     }
 

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -242,15 +242,21 @@ export async function subscribeToQuery<
       const errorData = JSON.parse((event as any).data) as ChannelErrorData;
 
       if (errorData.fatal) {
-        if (onStatusChange) {
-          onStatusChange('closed');
-        }
         stopReconnecting = true;
-        unsubscribe();
       }
 
       if (onChannelError) {
         onChannelError(errorData);
+      }
+
+      eventSource.close();
+
+      if (onStatusChange) {
+        onStatusChange('closed');
+      }
+
+      if (!stopReconnecting) {
+        waitAndReconnect();
       }
     });
 

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -207,6 +207,10 @@ export async function subscribeToQuery<
       onError(e)
     }
 
+    if (onStatusChange) {
+      onStatusChange('closed');
+    }
+
     return waitAndReconnect();
   }
 
@@ -252,6 +256,10 @@ export async function subscribeToQuery<
 
     eventSource.addEventListener('onerror', (event) => {
       eventSource.close();
+
+      if (onStatusChange) {
+        onStatusChange('closed');
+      }
 
       if (onError) {
         onError(event)

--- a/src/subscribeToQuery/index.ts
+++ b/src/subscribeToQuery/index.ts
@@ -87,7 +87,7 @@ export type Options<QueryResult, QueryVariables> = {
   /** Callback function to call on channel errors */
   onChannelError?: (errorData: ChannelErrorData) => void;
   /** Callback function to call on other errors */
-  onError?: (errorData: ErrorEvent) => void;
+  onError?: (errorData: MessageEvent) => void;
   /** Callback function to call on events during the connection lifecycle */
   onEvent?: (eventData: EventData) => void;
 };
@@ -199,7 +199,8 @@ export async function subscribeToQuery<
     }
 
     if (onError) {
-      const event = new ErrorEvent('FetchError', {message: e.message});
+      const data = JSON.stringify({message: e.message});
+      const event = new MessageEvent('FetchError', {data});
       onError(event)
     }
 
@@ -263,8 +264,9 @@ export async function subscribeToQuery<
         onStatusChange('closed');
       }
 
+      const messageEvent = (event as MessageEvent);
       if (onError) {
-        onError(event as ErrorEvent);
+        onError(messageEvent);
       }
 
       if (!stopReconnecting) {


### PR DESCRIPTION
This commit adds two callbacks, `onError` and `onEvent` to improve observability.

Attempts are made to recover from more error conditions, to avoid zombie connections that never reach 'connected' state.