### PR TITLE
Fix README documentation to match actual TypeScript types

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ const unsubscribe = await subscribeToQuery({
 
 ### `onUpdate(update: UpdateData<QueryResult>)`
 
-This function will be called everytime the channel sends an updated query result. The `updateData` argument has the following properties:
+This function will be called every time the channel sends an updated query result. The `updateData` argument has the following properties:
 
 | prop     | type   | description                  |
 | -------- | ------ | ---------------------------- |
@@ -119,7 +119,7 @@ The `status` argument represents the state of the server-sent events connection.
 
 - `connecting`: the subscription channel is trying to connect
 - `connected`: the channel is open, we're receiving live updates
-- `closed`: the channel has been permanently closed due to a fatal error (ie. an invalid query)
+- `closed`: the channel has been permanently closed due to a fatal error (i.e. an invalid query)
 
 ### `onChannelError(errorData: ChannelErrorData)`
 
@@ -127,8 +127,8 @@ The `errorData` argument has the following properties:
 
 | prop     | type    | description                                                        |
 | -------- | ------- | ------------------------------------------------------------------ |
-| code     | string  | The code of the error (ie. `INVALID_QUERY`)                        |
-| message  | string  | An human friendly message explaining the error                     |
+| code     | string  | The code of the error (i.e. `INVALID_QUERY`)                        |
+| message  | string  | A human-friendly message explaining the error                     |
 | fatal    | boolean | If true, the channel has been closed and will not reconnect        |
 | response | Object  | The raw response returned by the endpoint, if available (optional) |
 
@@ -140,7 +140,7 @@ The `error` argument is a standard [MessageEvent](https://developer.mozilla.org/
 
 ### `onEvent(event: EventData)`
 
-This function is called then other events occur.
+This function is called when other events occur.
 
 The `event` argument has the following properties:
 
@@ -148,7 +148,7 @@ The `event` argument has the following properties:
 | ---------- | -------- | ---------------------------------------------- |
 | status     | string   | The current connection status (see above)      |
 | channelUrl | string   | The current channel URL                        |
-| message    | string   | An human friendly message explaining the event |
+| message    | string   | A human-friendly message explaining the event  |
 | response   | Response | The HTTP response from the registration request |
 
 ## Return value

--- a/README.md
+++ b/README.md
@@ -65,18 +65,16 @@ const unsubscribe = await subscribeToQuery({
     console.error(error);
   },
   onError: (error) => {
-    // error will be
-    // {
-    //   message: "ERROR MESSAGE"
-    // }
-    console.log(error.message);
+    // error is a MessageEvent, the actual error is in error.data
+    console.log(error.data);
   },
   onEvent: (event) => {
     // event will be
     // {
-    //   status: "connected|connected|closed",
+    //   status: "connecting|connected|closed",
     //   channelUrl: "...",
     //   message: "MESSAGE",
+    //   response: Response
     // }
   },
 });
@@ -127,21 +125,18 @@ The `status` argument represents the state of the server-sent events connection.
 
 The `errorData` argument has the following properties:
 
-| prop     | type   | description                                             |
-| -------- | ------ | ------------------------------------------------------- |
-| code     | string | The code of the error (ie. `INVALID_QUERY`)             |
-| message  | string | An human friendly message explaining the error          |
-| response | Object | The raw response returned by the endpoint, if available |
+| prop     | type    | description                                                        |
+| -------- | ------- | ------------------------------------------------------------------ |
+| code     | string  | The code of the error (ie. `INVALID_QUERY`)                        |
+| message  | string  | An human friendly message explaining the error                     |
+| fatal    | boolean | If true, the channel has been closed and will not reconnect        |
+| response | Object  | The raw response returned by the endpoint, if available (optional) |
 
-### `onError(error: ErrorData)`
+### `onError(error: MessageEvent)`
 
-This function is called when connection errors occur.
+This function is called when connection errors occur (network errors, SSE errors).
 
-The `error` argument has the following properties:
-
-| prop    | type   | description                                    |
-| ------- | ------ | ---------------------------------------------- |
-| message | string | An human friendly message explaining the error |
+The `error` argument is a standard [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent). The actual error object is available in `error.data`.
 
 ### `onEvent(event: EventData)`
 
@@ -149,11 +144,12 @@ This function is called then other events occur.
 
 The `event` argument has the following properties:
 
-| prop       | type   | description                                    |
-| ---------- | ------ | ---------------------------------------------- |
-| status     | string | The current connection status (see above)      |
-| channelUrl | string | The current channel URL                        |
-| message    | string | An human friendly message explaining the event |
+| prop       | type     | description                                    |
+| ---------- | -------- | ---------------------------------------------- |
+| status     | string   | The current connection status (see above)      |
+| channelUrl | string   | The current channel URL                        |
+| message    | string   | An human friendly message explaining the event |
+| response   | Response | The HTTP response from the registration request |
 
 ## Return value
 


### PR DESCRIPTION
## Summary

This PR fixes several mismatches between the README documentation and the actual TypeScript type definitions in `src/subscribeToQuery/index.ts`.

## Changes

### 1. `onError` callback signature

**Problem:** The README documented `onError` as receiving an `ErrorData` object with a `message` property:

```typescript
// README claimed:
onError: (error: ErrorData) => void  // where ErrorData = { message: string }
```

**Reality:** The actual type definition at [`src/subscribeToQuery/index.ts:104`](src/subscribeToQuery/index.ts#L104) shows:

```typescript
onError?: (errorData: MessageEvent) => void;
```

And the callback is invoked with a `MessageEvent` in two places:

1. **Fetch errors** at [lines 237-239](src/subscribeToQuery/index.ts#L237-L239):
   ```typescript
   const event = new MessageEventClass<Error>('FetchError', { data: e });
   onError(event);
   ```

2. **SSE errors** at [lines 306-309](src/subscribeToQuery/index.ts#L306-L309):
   ```typescript
   eventSource.addEventListener('onerror', (event) => {
     const messageEvent = event as MessageEvent;
     if (onError) {
       onError(messageEvent);
     }
   ```

**Fix:** Updated documentation to correctly show `MessageEvent` as the parameter type, and updated the example to use `error.data` instead of `error.message`.

---

### 2. Missing `fatal` property in `onChannelError`

**Problem:** The README's `ChannelErrorData` table was missing the `fatal` property.

**Reality:** The actual type definition at [`src/subscribeToQuery/index.ts:50-59`](src/subscribeToQuery/index.ts#L50-L59) shows:

```typescript
export type ChannelErrorData = {
  /** The code of the error (ie. `INVALID_QUERY`) */
  code: string;
  /** An human friendly message explaining the error */
  message: string;
  /** If the error is not fatal (ie. the query is invalid), the query will be retried after some time */
  fatal: boolean;
  /** The raw error response, if available */
  response?: any;
};
```

The `fatal` property is actually used in the code at [lines 294-296](src/subscribeToQuery/index.ts#L294-L296) to determine whether to stop reconnection attempts:

```typescript
if (errorData.fatal) {
  stopReconnecting = true;
}
```

**Fix:** Added `fatal` property to the documentation table.

---

### 3. Missing `response` property in `onEvent`

**Problem:** The README's `EventData` table only documented `status`, `channelUrl`, and `message`.

**Reality:** The actual type definition at [`src/subscribeToQuery/index.ts:63-72`](src/subscribeToQuery/index.ts#L63-L72) shows:

```typescript
export type EventData = {
  /** The current status of the connection **/
  status: ConnectionStatus;
  /** The current channelUrl **/
  channelUrl: string;
  /** An event description **/
  message: string;
  /** Complete HTTP response */
  response: Response;
};
```

The `response` property is included when calling `onEvent` at [lines 228-235](src/subscribeToQuery/index.ts#L228-L235):

```typescript
if (onEvent) {
  onEvent({
    status: 'connecting',
    channelUrl,
    message: 'Received channel URL',
    response: req,
  });
}
```

**Fix:** Added `response` property to both the documentation table and the example comment.

---

### 4. Typo in example comment

**Problem:** The example comment showed `"connected|connected|closed"` (connected twice).

**Reality:** The `ConnectionStatus` type at [`src/subscribeToQuery/index.ts:61`](src/subscribeToQuery/index.ts#L61) is:

```typescript
export type ConnectionStatus = 'connecting' | 'connected' | 'closed';
```

**Fix:** Corrected to `"connecting|connected|closed"`.

## Test plan

- [x] Verified each fix against the source TypeScript definitions
- [ ] Review that documentation now accurately reflects the API

🤖 Generated with [Claude Code](https://claude.ai/code)